### PR TITLE
fix: add missing ItemMeta import in GuiFactory

### DIFF
--- a/lib/src/main/java/city/bit/auth/ui/GuiFactory.java
+++ b/lib/src/main/java/city/bit/auth/ui/GuiFactory.java
@@ -5,7 +5,9 @@ import city.bit.auth.i18n.Msg;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.*;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 /**
  * Відповідає за створення графічного інтерфейсу авторизації.
@@ -43,10 +45,10 @@ public class GuiFactory {
      * Створює предмет-кнопку з вказаним матеріалом та назвою.
      */
     private ItemStack button(Material mat, String name) {
-        ItemStack it = new ItemStack(mat);
-        ItemMeta im = it.getItemMeta();
-        im.setDisplayName(name);
-        it.setItemMeta(im);
-        return it;
+        ItemStack it = new ItemStack(mat); // створюємо предмет з потрібного матеріалу
+        ItemMeta im = it.getItemMeta(); // отримуємо мета-дані, що дозволяють змінювати властивості
+        im.setDisplayName(name); // встановлюємо назву, яку побачить гравець
+        it.setItemMeta(im); // записуємо змінені мета-дані назад у предмет
+        return it; // повертаємо готову «кнопку» для розміщення в інвентарі
     }
 }


### PR DESCRIPTION
## Summary
- add explicit imports for Inventory, ItemStack and ItemMeta in GuiFactory
- document button creation with detailed Ukrainian comments

## Testing
- `gradle test` *(fails: Could not resolve io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68c75d8a35188320bddb5143068fded9